### PR TITLE
Switch to requests to fix https

### DIFF
--- a/sentry-kubernetes.py
+++ b/sentry-kubernetes.py
@@ -2,6 +2,7 @@ from kubernetes import client, config, watch
 from kubernetes.client.rest import ApiException
 from raven import breadcrumbs
 from raven import Client as SentryClient
+from raven.transport.threaded_requests import ThreadedRequestsHTTPTransport
 
 import argparse
 import logging
@@ -61,6 +62,7 @@ def watch_loop():
         include_versions=False,
         capture_locals=False,
         context={},
+        transport=ThreadedRequestsHTTPTransport,
     )
 
     # try:


### PR DESCRIPTION
This is awesome, thanks so much for getting this going.  

When I tried running this, I got SSL exceptions since I wasn't setting `ca_certs` or willing to drop `verify_ssl`. By switching to the Requests transport SSL now works fine without having to pass a CA cert.  Not sure if this is done on purpose but I figured I would send this over since it could save some people some time!