### PR TITLE
reduce mangling of involved object names

### DIFF
--- a/sentry-kubernetes.py
+++ b/sentry-kubernetes.py
@@ -28,6 +28,7 @@ DSN = os.environ.get('DSN')
 ENV = os.environ.get('ENVIRONMENT')
 RELEASE = os.environ.get('RELEASE')
 EVENT_NAMESPACE = os.environ.get('EVENT_NAMESPACE')
+MANGLE_NAMES = [name for name in os.environ.get('MANGLE_NAMES', default='').split(',') if name]
 
 
 def main():
@@ -121,7 +122,7 @@ def watch_loop():
 
         if event.involved_object and event.involved_object.name:
             name = event.involved_object.name
-            if kind in ("Pod", "ReplicaSet", "StatefulSet"):
+            if kind in MANGLE_NAMES:
                 bits = name.split('-')
                 if len(bits) in (1, 2):
                     short_name = bits[0]

--- a/sentry-kubernetes.py
+++ b/sentry-kubernetes.py
@@ -122,7 +122,7 @@ def watch_loop():
 
         if event.involved_object and event.involved_object.name:
             name = event.involved_object.name
-            if kind in MANGLE_NAMES:
+            if not MANGLE_NAMES or kind in MANGLE_NAMES:
                 bits = name.split('-')
                 if len(bits) in (1, 2):
                     short_name = bits[0]

--- a/sentry-kubernetes.py
+++ b/sentry-kubernetes.py
@@ -116,16 +116,19 @@ def watch_loop():
         elif 'namespace' in meta:
             namespace = meta['namespace']
 
-        if event.involved_object and event.involved_object.name:
-            name = event.involved_object.name
-            bits = name.split('-')
-            if len(bits) in (1, 2):
-                short_name = bits[0]
-            else:
-                short_name = "-".join(bits[:-2])
-
         if event.involved_object and event.involved_object.kind:
             kind = event.involved_object.kind
+
+        if event.involved_object and event.involved_object.name:
+            name = event.involved_object.name
+            if kind in ("Pod", "ReplicaSet", "StatefulSet"):
+                bits = name.split('-')
+                if len(bits) in (1, 2):
+                    short_name = bits[0]
+                else:
+                    short_name = "-".join(bits[:-2])
+            else:
+                short_name = name
 
         message = event.message
 


### PR DESCRIPTION
The short_name logic seems to be targeted at pods, replicasets, and
statefulsets where parts of the name can be auto generated. In other
cases the short_name mangling is undesirable as it throws away relevant
parts of the name when the name contains dashes.  For example a Service
called "my-lb" would appear in the culprit only as "my".

This is an improvement but still imperfect because 1) it is quite
possible to create many of these objects directly without any generated
suffix and 2) even when a suffix is appended it is not always 2 segments
as currently assumed. A more complete fix likely requires querying
kubernetes for details about the involved object and determining the
closest object that is not automatically created by kubernetes to
attribute the culprit to.