### PR TITLE
Optionally only listen to events of a single namespace

### DIFF
--- a/sentry-kubernetes.py
+++ b/sentry-kubernetes.py
@@ -27,6 +27,7 @@ LEVEL_MAPPING = {
 DSN = os.environ.get('DSN')
 ENV = os.environ.get('ENVIRONMENT')
 RELEASE = os.environ.get('RELEASE')
+EVENT_NAMESPACE = os.environ.get('EVENT_NAMESPACE')
 
 
 def main():
@@ -76,7 +77,12 @@ def watch_loop():
     # except:
     #     resource_version = 0
 
-    for event in w.stream(v1.list_event_for_all_namespaces):
+    if EVENT_NAMESPACE:
+        stream = w.stream(v1.list_namespaced_event, EVENT_NAMESPACE)
+    else:
+        stream = w.stream(v1.list_event_for_all_namespaces)
+
+    for event in stream:
         logging.debug("event: %s" % event)
 
         event_type = event['type'].lower()


### PR DESCRIPTION
In some setups one doesn't necessarily have the permission to listen to
events of the whole cluster. With multiple teams using a single cluster
not all events should go to the same sentry project.

By optionally settings the EVENT_NAMESPACE environment variable, only
events for that namespace will be reported.

---

By the way, I'm happy to have discovered this project last week. I think it'll help our transition to OpenShift by providing more visibility into what happens in the cluster.
