### PR TITLE
Add environmnt variable DISABLE_SSL_VERIFY

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ See the full list in sentry-kubernetes.py
 
 | ENV var | Description |
 ---------|-------------
+LOG_LEVEL | The root log level, defaults to 'error'.
+DSN | Data source name for sentry project.
+ENVIRONMENT | [Environment](https://docs.sentry.io/enriching-error-data/environments/) for sentry project.
+RELEASE | [Release](https://docs.sentry.io/workflow/releases/) for sentry project.
+CLUSTER_NAME | Included as an event tag for searching.
+DISABLE_SSL_VERIFY | Set to turn off `verify_ssl` of k8s python client, defaults to False. 
 EVENT_NAMESPACES_EXCLUDED | A comma-separated list of namespaces. Ex.: 'qa,demo'. Events from these namespaces won't be sent to Sentry.
 
 ---

--- a/sentry-kubernetes.py
+++ b/sentry-kubernetes.py
@@ -21,6 +21,7 @@ DSN = os.environ.get("DSN")
 ENV = os.environ.get("ENVIRONMENT")
 RELEASE = os.environ.get("RELEASE")
 CLUSTER_NAME = os.environ.get("CLUSTER_NAME")
+DISABLE_SSL_VERIFY = os.environ.get("DISABLE_SSL_VERIFY")
 
 
 def _listify_env(name, default=None):
@@ -57,6 +58,11 @@ def main():
     log_level = args.log_level.upper()
     logging.basicConfig(format="%(asctime)s %(message)s", level=log_level)
     logging.debug("log_level: %s" % log_level)
+
+    if DISABLE_SSL_VERIFY:
+        configuration = client.Configuration()
+        configuration.verify_ssl=False
+        client.Configuration.set_default(configuration)
 
     try:
         config.load_incluster_config()


### PR DESCRIPTION
`CERTIFICATE_VERIFY_FAILED` is a common [issue](https://github.com/kubernetes-client/python/issues/490) for k8s python client and I have this problem with the cluster provided by AliCloud. It would be convenient to have an env var to disable ca ssl verification.