### PR TITLE
Fix: add mutex protection for monitor metadata

### DIFF
--- a/crons_monitor_data.go
+++ b/crons_monitor_data.go
@@ -60,8 +60,8 @@ func NewCronsMonitorData(monitorSlug string, schedule string, maxRunTime int64, 
 // Add a job to the crons monitor
 func (c *CronsMonitorData) addJob(job *batchv1.Job, checkinId sentry.EventID) error {
 	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	c.JobDatas[job.Name] = NewCronsJobData(checkinId)
-	c.mutex.Unlock()
 	return nil
 }
 
@@ -74,20 +74,20 @@ type CronsMetaData struct {
 
 func (c *CronsMetaData) addCronsMonitorData(cronjobName string, newCronsMonitorData *CronsMonitorData) {
 	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	c.cronsMonitorDataMap[cronjobName] = newCronsMonitorData
-	c.mutex.Unlock()
 }
 
 func (c *CronsMetaData) deleteCronsMonitorData(cronjobName string) {
 	c.mutex.Lock()
+	defer c.mutex.Unlock()
 	delete(c.cronsMonitorDataMap, cronjobName)
-	c.mutex.Unlock()
 }
 
 func (c *CronsMetaData) getCronsMonitorData(cronjobName string) (*CronsMonitorData, bool) {
 	c.mutex.RLock()
+	defer c.mutex.RUnlock()
 	cronsMonitorData, ok := c.cronsMonitorDataMap[cronjobName]
-	c.mutex.RUnlock()
 	return cronsMonitorData, ok
 }
 

--- a/informer_crons.go
+++ b/informer_crons.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 
 	"github.com/rs/zerolog"
 	batchv1 "k8s.io/api/batch/v1"
@@ -17,17 +16,6 @@ func createCronjobInformer(ctx context.Context, factory informers.SharedInformer
 
 	logger.Debug().Msgf("Starting cronJob informer\n")
 
-	val := ctx.Value(CronsInformerDataKey{})
-	if val == nil {
-		return nil, errors.New("no crons informer data struct given")
-	}
-
-	var cronsInformerData *map[string]CronsMonitorData
-	var ok bool
-	if cronsInformerData, ok = val.(*map[string]CronsMonitorData); !ok {
-		return nil, errors.New("cannot convert cronsInformerData value from context")
-	}
-
 	cronjobInformer := factory.Batch().V1().CronJobs().Informer()
 
 	var handler cache.ResourceEventHandlerFuncs
@@ -35,20 +23,20 @@ func createCronjobInformer(ctx context.Context, factory informers.SharedInformer
 	handler.AddFunc = func(obj interface{}) {
 		cronjob := obj.(*batchv1.CronJob)
 		logger.Debug().Msgf("ADD: CronJob Added to Store: %s\n", cronjob.GetName())
-		_, ok := (*cronsInformerData)[cronjob.Name]
+		_, ok := cronsMetaData.getCronsMonitorData(cronjob.Name)
 		if ok {
 			logger.Debug().Msgf("cronJob %s already exists in the crons informer data struct...\n", cronjob.Name)
 		} else {
-			(*cronsInformerData)[cronjob.Name] = *NewCronsMonitorData(cronjob.Name, cronjob.Spec.Schedule, 5, 3, cronjob.Spec.JobTemplate.Spec.Completions)
+			cronsMetaData.addCronsMonitorData(cronjob.Name, NewCronsMonitorData(cronjob.Name, cronjob.Spec.Schedule, 5, 3, cronjob.Spec.JobTemplate.Spec.Completions))
 		}
 	}
 
 	handler.DeleteFunc = func(obj interface{}) {
 		cronjob := obj.(*batchv1.CronJob)
 		logger.Debug().Msgf("DELETE: CronJob deleted from Store: %s\n", cronjob.GetName())
-		_, ok := (*cronsInformerData)[cronjob.Name]
+		_, ok := cronsMetaData.getCronsMonitorData(cronjob.Name)
 		if ok {
-			delete((*cronsInformerData), cronjob.Name)
+			cronsMetaData.deleteCronsMonitorData(cronjob.Name)
 			logger.Debug().Msgf("cronJob %s deleted from the crons informer data struct...\n", cronjob.Name)
 		} else {
 			logger.Debug().Msgf("cronJob %s not in the crons informer data struct...\n", cronjob.Name)

--- a/informer_jobs.go
+++ b/informer_jobs.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 
 	"github.com/rs/zerolog"
 	batchv1 "k8s.io/api/batch/v1"
@@ -16,11 +15,6 @@ func createJobInformer(ctx context.Context, factory informers.SharedInformerFact
 	logger := zerolog.Ctx(ctx)
 
 	logger.Debug().Msgf("starting job informer\n")
-
-	val := ctx.Value(CronsInformerDataKey{})
-	if val == nil {
-		return nil, errors.New("no crons informer data struct given")
-	}
 
 	jobInformer := factory.Batch().V1().Jobs().Informer()
 

--- a/watcher_pods.go
+++ b/watcher_pods.go
@@ -77,11 +77,6 @@ func handlePodWatchEvent(ctx context.Context, event *watch.Event) {
 
 	eventObjectRaw := event.Object
 
-	// err := runSentryCronsCheckin(ctx, event)
-	// if err != nil {
-	// 	return
-	// }
-
 	if event.Type != watch.Modified {
 		logger.Debug().Msgf("Skipping a pod watch event of type %s", event.Type)
 		return
@@ -188,18 +183,13 @@ func watchPodsInNamespaceForever(ctx context.Context, config *rest.Config, names
 
 	ctx = setClientsetOnContext(ctx, clientset)
 
-	// create the informers to integrate with sentry crons
+	// Create the informers to integrate with sentry crons
 	if isTruthy(os.Getenv("SENTRY_K8S_MONITOR_CRONJOBS")) {
-		// cronsInformerData := make(map[string]CronsMonitorData)
-		// ctx := context.WithValue(ctx, CronsInformerDataKey{}, &cronsInformerData)
 		logger.Info().Msgf("Enabling CronJob monitoring")
-
 		go startCronsInformers(ctx, namespace)
-
 	} else {
 		logger.Info().Msgf("CronJob monitoring is disabled")
 	}
-
 	for {
 		if err := watchPodsInNamespace(ctx, namespace); err != nil {
 			logger.Error().Msgf("Error while watching pods %s: %s", where, err)

--- a/watcher_pods.go
+++ b/watcher_pods.go
@@ -19,6 +19,8 @@ import (
 
 const podsWatcherName = "pods"
 
+var cronsMetaData = NewCronsMetaData()
+
 func handlePodTerminationEvent(ctx context.Context, containerStatus *v1.ContainerStatus, pod *v1.Pod, scope *sentry.Scope) *sentry.Event {
 	logger := zerolog.Ctx(ctx)
 
@@ -188,8 +190,8 @@ func watchPodsInNamespaceForever(ctx context.Context, config *rest.Config, names
 
 	// create the informers to integrate with sentry crons
 	if isTruthy(os.Getenv("SENTRY_K8S_MONITOR_CRONJOBS")) {
-		cronsInformerData := make(map[string]CronsMonitorData)
-		ctx := context.WithValue(ctx, CronsInformerDataKey{}, &cronsInformerData)
+		// cronsInformerData := make(map[string]CronsMonitorData)
+		// ctx := context.WithValue(ctx, CronsInformerDataKey{}, &cronsInformerData)
 		logger.Info().Msgf("Enabling CronJob monitoring")
 
 		go startCronsInformers(ctx, namespace)


### PR DESCRIPTION
Add mutex protection for slug monitor metadata shared by the event handlers of the cronjob and job informers