### PR TITLE
tests: add test cronjob manifests for errors and delays

### DIFF
--- a/k8s/errors/cronjob-late-maybe-error.yaml
+++ b/k8s/errors/cronjob-late-maybe-error.yaml
@@ -1,19 +1,19 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: cronjob-basic-error
+  name: cronjob-late-maybe-error
   labels:
     type: test-pod
 spec:
   schedule: "* * * * *"
   jobTemplate:
     spec:
-      backoffLimit: 2
+      backoffLimit: 0
       template:
         metadata:
           labels:
             type: test-pod
-            run: cronjob-basic-error
+            run: cronjob-late-maybe-error
         spec:
           containers:
             - name: hello
@@ -22,5 +22,12 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - sleep 1; invalid_command
+                - |
+                  MINWAIT=0
+                  MAXWAIT=60
+                  sleep $((MINWAIT+RANDOM % (MAXWAIT-MINWAIT)))
+                  sleep 3
+                  r=$((RANDOM%2))
+                  if [ $r -eq 0 ]; then echo Hello!; fi
+                  if [ $r -eq 1 ]; then exit 1; fi
           restartPolicy: Never

--- a/k8s/errors/cronjob-late-maybe-error.yaml
+++ b/k8s/errors/cronjob-late-maybe-error.yaml
@@ -28,6 +28,5 @@ spec:
                   sleep $((MINWAIT+RANDOM % (MAXWAIT-MINWAIT)))
                   sleep 3
                   r=$((RANDOM%2))
-                  if [ $r -eq 0 ]; then echo Hello!; fi
-                  if [ $r -eq 1 ]; then exit 1; fi
+                  if [ $r -eq 0 ]; then echo Hello!; else exit 1; fi
           restartPolicy: Never

--- a/k8s/errors/cronjob-late-success.yaml
+++ b/k8s/errors/cronjob-late-success.yaml
@@ -1,19 +1,18 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: cronjob-basic-error
+  name: cronjob-late-success
   labels:
     type: test-pod
 spec:
   schedule: "* * * * *"
   jobTemplate:
     spec:
-      backoffLimit: 2
       template:
         metadata:
           labels:
             type: test-pod
-            run: cronjob-basic-error
+            run: cronjob-late-success
         spec:
           containers:
             - name: hello
@@ -22,5 +21,10 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - sleep 1; invalid_command
+                - |
+                  date 
+                  MINWAIT=0
+                  MAXWAIT=60
+                  sleep $((MINWAIT+RANDOM % (MAXWAIT-MINWAIT)))
+                  echo Hello!
           restartPolicy: Never

--- a/k8s/errors/cronjob-maybe-error.yaml
+++ b/k8s/errors/cronjob-maybe-error.yaml
@@ -1,19 +1,19 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: cronjob-basic-error
+  name: cronjob-maybe-error
   labels:
     type: test-pod
 spec:
   schedule: "* * * * *"
   jobTemplate:
     spec:
-      backoffLimit: 2
+      backoffLimit: 0
       template:
         metadata:
           labels:
             type: test-pod
-            run: cronjob-basic-error
+            run: cronjob-maybe-error
         spec:
           containers:
             - name: hello
@@ -22,5 +22,9 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - sleep 1; invalid_command
+                - |
+                  sleep 3
+                  r=$((RANDOM%2))
+                  if [ $r -eq 0 ]; then echo Hello!; fi
+                  if [ $r -eq 1 ]; then exit 1; fi
           restartPolicy: Never

--- a/k8s/errors/cronjob-maybe-error.yaml
+++ b/k8s/errors/cronjob-maybe-error.yaml
@@ -25,6 +25,5 @@ spec:
                 - |
                   sleep 3
                   r=$((RANDOM%2))
-                  if [ $r -eq 0 ]; then echo Hello!; fi
-                  if [ $r -eq 1 ]; then exit 1; fi
+                  if [ $r -eq 0 ]; then echo Hello!; else exit 1; fi
           restartPolicy: Never


### PR DESCRIPTION
Previously: We did not have cronjob manifests that tested tasks of variable durations that either succeeded or failed.

Now:

We created new manifests to test the following cases:

`cronjob-late-success`: similar to `cronjob-basic-success` but the task first sleeps for an interval between 0 seconds to 60 seconds. This tests how Crons registers the late checkin during exit.

`cronjob-maybe-error`: this task either errors or succeeds with equal chance

`cronjob-late-maybe-error`: this task also has variable duration but may either succeed or error with equal chance