### PR TITLE
fix: correct fingerprinting and common enhancer call

### DIFF
--- a/enhancers.go
+++ b/enhancers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/rs/zerolog"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -16,17 +17,19 @@ const breadcrumbLimit = 20
 
 func runEnhancers(ctx context.Context, eventObject *v1.Event, kind string, object metav1.Object, scope *sentry.Scope, sentryEvent *sentry.Event) error {
 
-	involvedObject := fmt.Sprintf("%s/%s", kind, object.GetName())
-	ctx, logger := getLoggerWithTag(ctx, "object", involvedObject)
+	logger := zerolog.Ctx(ctx)
 	logger.Debug().Msgf("Running the enhancer")
 
 	var err error
 
-	// First, run the common enhancer
+	// First, run the common enhancer which
+	// does not need neither the event object
+	// nor the involved object
 	err = runCommonEnhancer(ctx, scope, sentryEvent)
 	if err != nil {
 		return err
 	}
+
 	// If an event object is provided, we call the event enhancer
 	if eventObject != nil {
 		err = eventEnhancer(ctx, scope, eventObject, sentryEvent)
@@ -35,129 +38,23 @@ func runEnhancers(ctx context.Context, eventObject *v1.Event, kind string, objec
 		}
 	}
 
-	logger.Trace().Msgf("Current fingerprint: %v", sentryEvent.Fingerprint)
-	// Enhance message with object name
-	message := sentryEvent.Message
-	sentryEvent.Message = fmt.Sprintf("%s: %s", object.GetName(), sentryEvent.Message)
-
-	// Adjust fingerprint.
-	// If there's already a non-empty fingerprint set, we assume that it was set by
-	// another enhancer, so we don't touch it.
-	if len(sentryEvent.Fingerprint) == 0 {
-		sentryEvent.Fingerprint = []string{message}
-	}
-	logger.Trace().Msgf("Fingerprint after adjustment: %v", sentryEvent.Fingerprint)
-
-	// Find the root owners and their corresponding object kinds
-	rootOwners, err := findRootOwners(ctx, &KindObjectPair{
-		kind:   kind,
-		object: object,
-	})
-	if err != nil {
-		return err
-	}
-
-	// Might reset back to old fingerprint if
-	// there exists root owner(s) to the object
-	oldFingerprint := sentryEvent.Fingerprint
-	// Call the specific enhancer for the object
-	callObjectEnhancer(ctx, scope, &KindObjectPair{
-		kind,
-		object,
-	}, sentryEvent)
-	// Remove any fingerprinting so the event
-	// can be grouped by its owners instead
-	if len(rootOwners) != 0 {
-		sentryEvent.Fingerprint = oldFingerprint
-	}
-
-	// Call specific enhancers for all root owners
-	// (there most likely is just one root owner)
-	for _, rootOwner := range rootOwners {
-		callObjectEnhancer(ctx, scope, &rootOwner, sentryEvent)
+	// If an involved object is provided, we call the object enhancer
+	if object != nil {
+		err = objectEnhancer(ctx, scope, &KindObjectPair{
+			kind:   kind,
+			object: object,
+		}, sentryEvent)
 		if err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
 type KindObjectPair struct {
 	kind   string
 	object metav1.Object
-}
-
-// Finds the root owning objects of an object
-// and returns an empty slice if the object has
-// no owning objects
-func findRootOwners(ctx context.Context, kindObjPair *KindObjectPair) ([]KindObjectPair, error) {
-
-	// Use DFS to find the leaves of the owner references graph
-	rootOwners, err := ownerRefDFS(ctx, kindObjPair)
-	if err != nil {
-		return nil, err
-	}
-
-	// If the object has no owner references
-	if rootOwners[0].object.GetUID() == kindObjPair.object.GetUID() {
-		return []KindObjectPair{}, nil
-	}
-
-	return rootOwners, nil
-
-}
-
-// Performs DFS to find the leaves the owner references graph
-func ownerRefDFS(ctx context.Context, kindObjPair *KindObjectPair) ([]KindObjectPair, error) {
-
-	parents := kindObjPair.object.GetOwnerReferences()
-	// the owners slice to be returned
-	rootOwners := []KindObjectPair{}
-
-	// base case: the object has no parents
-	if len(parents) == 0 {
-		rootOwners = append(rootOwners, *kindObjPair)
-		return rootOwners, nil
-	}
-
-	// recursive case: the object has parents to explore
-	for _, parent := range parents {
-		parentObj, ok := findObject(ctx, parent.Kind, kindObjPair.object.GetNamespace(), parent.Name)
-		if !ok {
-			return nil, errors.New("error attempting to find root owneres")
-		}
-		partialOwners, err := ownerRefDFS(ctx, &KindObjectPair{
-			kind:   parent.Kind,
-			object: parentObj,
-		})
-		if err != nil {
-			return nil, err
-		}
-		if partialOwners != nil {
-			rootOwners = append(rootOwners, partialOwners...)
-		}
-	}
-	return rootOwners, nil
-}
-
-func callObjectEnhancer(ctx context.Context, scope *sentry.Scope, kindObjectPair *KindObjectPair, sentryEvent *sentry.Event) error {
-
-	var err error = nil
-	switch kindObjectPair.kind {
-	case KindPod:
-		err = podEnhancer(ctx, scope, kindObjectPair.object, sentryEvent)
-	case KindReplicaset:
-		err = replicaSetEnhancer(ctx, scope, kindObjectPair.object, sentryEvent)
-	case KindDeployment:
-		err = deploymentEnhancer(ctx, scope, kindObjectPair.object, sentryEvent)
-	case KindJob:
-		err = jobEnhancer(ctx, scope, kindObjectPair.object, sentryEvent)
-	case KindCronjob:
-		err = cronjobEnhancer(ctx, scope, kindObjectPair.object, sentryEvent)
-	default:
-		sentryEvent.Fingerprint = append(sentryEvent.Fingerprint, kindObjectPair.object.GetName())
-	}
-	return err
 }
 
 func eventEnhancer(ctx context.Context, scope *sentry.Scope, object metav1.Object, sentryEvent *sentry.Event) error {
@@ -188,6 +85,79 @@ func eventEnhancer(ctx context.Context, scope *sentry.Scope, object metav1.Objec
 	}
 
 	return nil
+}
+
+func objectEnhancer(ctx context.Context, scope *sentry.Scope, kindObjectPair *KindObjectPair, sentryEvent *sentry.Event) error {
+
+	objectTag := fmt.Sprintf("%s/%s", kindObjectPair.kind, kindObjectPair.object.GetName())
+	ctx, logger := getLoggerWithTag(ctx, "object", objectTag)
+
+	var err error = nil
+
+	logger.Trace().Msgf("Current fingerprint: %v", sentryEvent.Fingerprint)
+
+	// Enhance message with object name
+	message := sentryEvent.Message
+	sentryEvent.Message = fmt.Sprintf("%s: %s", kindObjectPair.object.GetName(), sentryEvent.Message)
+
+	// Adjust fingerprint.
+	// If there's already a non-empty fingerprint set, we assume that it was set by
+	// another enhancer, so we don't touch it.
+	if len(sentryEvent.Fingerprint) == 0 {
+		sentryEvent.Fingerprint = []string{message}
+	}
+	logger.Trace().Msgf("Fingerprint after adjustment: %v", sentryEvent.Fingerprint)
+
+	// Find the root owners and their corresponding object kinds
+	rootOwners, err := findRootOwners(ctx, kindObjectPair)
+	if err != nil {
+		return err
+	}
+
+	// Might reset back to old fingerprint if
+	// there exists root owner(s) to the object
+	oldFingerprint := sentryEvent.Fingerprint
+	// Call the specific enhancer for the object
+	err = getKindEnhancer(kindObjectPair.kind)(ctx, scope, kindObjectPair.object, sentryEvent)
+	if err != nil {
+		return err
+	}
+	// Remove any fingerprinting so the event
+	// can be grouped by its owners instead
+	if len(rootOwners) != 0 {
+		sentryEvent.Fingerprint = oldFingerprint
+	}
+
+	// Call specific enhancers for all root owners
+	// (there most likely is just one root owner)
+	for _, rootOwner := range rootOwners {
+		err = getKindEnhancer(rootOwner.kind)(ctx, scope, rootOwner.object, sentryEvent)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getKindEnhancer(kind string) func(context.Context, *sentry.Scope, metav1.Object, *sentry.Event) error {
+	switch kind {
+	case KindPod:
+		return podEnhancer
+	case KindReplicaset:
+		return replicaSetEnhancer
+	case KindDeployment:
+		return deploymentEnhancer
+	case KindJob:
+		return jobEnhancer
+	case KindCronjob:
+		return cronjobEnhancer
+	default:
+		return func(ctx context.Context, scope *sentry.Scope, object metav1.Object, sentryEvent *sentry.Event) error {
+			sentryEvent.Fingerprint = append(sentryEvent.Fingerprint, object.GetName())
+			return nil
+		}
+	}
 }
 
 func podEnhancer(ctx context.Context, scope *sentry.Scope, object metav1.Object, sentryEvent *sentry.Event) error {
@@ -347,4 +317,56 @@ func deploymentEnhancer(ctx context.Context, scope *sentry.Scope, object metav1.
 	}, breadcrumbLimit)
 
 	return nil
+}
+
+// Finds the root owning objects of an object
+// and returns an empty slice if the object has
+// no owning objects
+func findRootOwners(ctx context.Context, kindObjPair *KindObjectPair) ([]KindObjectPair, error) {
+
+	// Use DFS to find the leaves of the owner references graph
+	rootOwners, err := ownerRefDFS(ctx, kindObjPair)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the object has no owner references
+	if rootOwners[0].object.GetUID() == kindObjPair.object.GetUID() {
+		return []KindObjectPair{}, nil
+	}
+
+	return rootOwners, nil
+}
+
+// Performs DFS to find the leaves the owner references graph
+func ownerRefDFS(ctx context.Context, kindObjPair *KindObjectPair) ([]KindObjectPair, error) {
+
+	parents := kindObjPair.object.GetOwnerReferences()
+	// the owners slice to be returned
+	rootOwners := []KindObjectPair{}
+
+	// base case: the object has no parents
+	if len(parents) == 0 {
+		rootOwners = append(rootOwners, *kindObjPair)
+		return rootOwners, nil
+	}
+
+	// recursive case: the object has parents to explore
+	for _, parent := range parents {
+		parentObj, ok := findObject(ctx, parent.Kind, kindObjPair.object.GetNamespace(), parent.Name)
+		if !ok {
+			return nil, errors.New("error attempting to find root owneres")
+		}
+		partialOwners, err := ownerRefDFS(ctx, &KindObjectPair{
+			kind:   parent.Kind,
+			object: parentObj,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if partialOwners != nil {
+			rootOwners = append(rootOwners, partialOwners...)
+		}
+	}
+	return rootOwners, nil
 }

--- a/watcher_events.go
+++ b/watcher_events.go
@@ -78,12 +78,15 @@ func buildSentryEventFromGeneralEvent(ctx context.Context, event *v1.Event, scop
 
 	involvedObj, ok := findObject(ctx, event.InvolvedObject.Kind, event.InvolvedObject.Namespace, event.InvolvedObject.Name)
 
-	// cannot find event
+	// Cannot find the involved object related to the event
+	// note: this may mean the object is not a supported kind
+	// (e.g. Node, Service, StatefulSets)
 	if !ok {
+		runCommonEnhancer(ctx, scope, sentryEvent)
 		return sentryEvent
 	}
 
-	// run enhancers with the involved object
+	// Run enhancers with the involved object
 	runEnhancers(ctx, event, event.InvolvedObject.Kind, involvedObj, scope, sentryEvent)
 	return sentryEvent
 }

--- a/watcher_events.go
+++ b/watcher_events.go
@@ -76,18 +76,14 @@ func handleGeneralEvent(ctx context.Context, eventObject *v1.Event, scope *sentr
 func buildSentryEventFromGeneralEvent(ctx context.Context, event *v1.Event, scope *sentry.Scope) *sentry.Event {
 	sentryEvent := &sentry.Event{Message: event.Message, Level: sentry.LevelError}
 
-	involvedObj, ok := findObject(ctx, event.InvolvedObject.Kind, event.InvolvedObject.Namespace, event.InvolvedObject.Name)
+	involvedObj, _ := findObject(ctx, event.InvolvedObject.Kind, event.InvolvedObject.Namespace, event.InvolvedObject.Name)
 
-	// Cannot find the involved object related to the event
-	// note: this may mean the object is not a supported kind
-	// (e.g. Node, Service, StatefulSets)
-	if !ok {
-		runCommonEnhancer(ctx, scope, sentryEvent)
-		return sentryEvent
-	}
-
-	// Run enhancers with the involved object
+	// Run enhancers on the event
+	// note: the involved object may be unsupported
+	// in which case it would be nil but that is handled
+	// correctly in the enhancers
 	runEnhancers(ctx, event, event.InvolvedObject.Kind, involvedObj, scope, sentryEvent)
+
 	return sentryEvent
 }
 


### PR DESCRIPTION
Issues Addressed:

1. If the involved object has owners, then the fingerprint now only includes the owners' kind and name so all objects with the same root owner are grouped. For example, if the involved object is a pod and it is owned by a deployment, the fingerprint will not include `Pod` or `<pod_name>` but instead `Deployment` and `<deployment_name>`.
2. Currently, the general enhancer only supports a subset of workload resource objects (Pod, Job, CronJob, ReplicaSet, Deployment) but not others (e.g. Node, Service, StatefulSet). We now call the common enhancer on the involved object regardless of whether the general enhancer supports that object. This way, the event message can at least be enhanced if needed.