### PR TITLE
feat: enable multiarch build

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         arch:
           - linux/amd64
-          # - linux/arm64
+          - linux/arm64
     permissions:
       packages: write
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 
 # Build the application
 FROM golang:1.20 AS build-stage
-ARG TARGETARCH
 
 WORKDIR /app
 
@@ -11,7 +10,7 @@ RUN go mod download
 
 COPY *.go ./
 
-ENV CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETPLATFORM GO111MODULE=on
+ENV CGO_ENABLED=0 GOOS=${TARGETPLATFORM} GOARCH=${TARGETARCH} GO111MODULE=on
 
 RUN go build -o /bin/sentry-kubernetes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Build the application
 FROM golang:1.20 AS build-stage
-ARG TARGETPLATFORM
+ARG TARGETARCH
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 
 # Build the application
 FROM golang:1.20 AS build-stage
+ARG TARGETPLATFORM
 
 WORKDIR /app
 
@@ -10,7 +11,7 @@ RUN go mod download
 
 COPY *.go ./
 
-ENV CGO_ENABLED=0 GOOS=linux
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETPLATFORM GO111MODULE=on
 
 RUN go build -o /bin/sentry-kubernetes
 


### PR DESCRIPTION
Hello!

by adding the architecture in the GOARCH variable it should be compile faster and work better for the https://github.com/getsentry/sentry-kubernetes/issues/71

I didn't update the version of the various actions because maybe there is a motive for them to be that specific and I don't know.

Locally i tried `TARGETPLATFORM` and `TARGETARCH`
