### PR TITLE
Add nil check for cronjobRef.Controller

### DIFF
--- a/crons.go
+++ b/crons.go
@@ -35,7 +35,7 @@ func runSentryCronsCheckin(ctx context.Context, job *batchv1.Job, eventHandlerTy
 		return errors.New("job does not have cronjob reference")
 	}
 	cronjobRef := job.OwnerReferences[0]
-	if !*cronjobRef.Controller || cronjobRef.Kind != KindCronjob {
+	if cronjobRef.Controller == nil || !*cronjobRef.Controller || cronjobRef.Kind != KindCronjob {
 		return errors.New("job does not have cronjob reference")
 	}
 	cronsMonitorData, ok := cronsMetaData.getCronsMonitorData(cronjobRef.Name)


### PR DESCRIPTION
Simple fix to a segfault when automatic CRON monitoring is enabled.

Resolves https://github.com/getsentry/sentry-kubernetes/issues/90